### PR TITLE
Fix bug of AGI commands containing space

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,3 @@
+[
+  inputs: ["*.{ex,exs}", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/lib/elixir_agi.ex
+++ b/lib/elixir_agi.ex
@@ -20,13 +20,13 @@ defmodule ElixirAgi do
 
   def start(_type, _args) do
     import Supervisor.Spec, warn: false
-    Logger.debug "ElixirAgi: Starting app"
+    Logger.debug("ElixirAgi: Starting app")
 
     children = [
       supervisor(ElixirAgi.Supervisor.Main, [])
     ]
 
     opts = [strategy: :one_for_one]
-    Supervisor.start_link children, opts
+    Supervisor.start_link(children, opts)
   end
 end

--- a/lib/elixir_agi/agi.ex
+++ b/lib/elixir_agi/agi.ex
@@ -23,13 +23,12 @@ defmodule ElixirAgi.Agi do
   require Logger
   alias ElixirAgi.Agi.Result
 
-  defstruct \
-    init: nil,
-    close: nil,
-    reader: nil,
-    writer: nil,
-    debug: false,
-    variables: %{}
+  defstruct init: nil,
+            close: nil,
+            reader: nil,
+            writer: nil,
+            debug: false,
+            variables: %{}
 
   @type t :: ElixirAgi.Agi
   @type reader :: function
@@ -39,13 +38,14 @@ defmodule ElixirAgi.Agi do
 
   defmacro log(level, message) do
     quote bind_quoted: [
-      level: level,
-      message: message
-    ] do
-      agi = var! agi
-      level_str = to_string level
-      if((level_str !== "debug") or agi.debug) do
-        Logger.bare_log level, "ElixirAgi AGI: #{message}"
+            level: level,
+            message: message
+          ] do
+      agi = var!(agi)
+      level_str = to_string(level)
+
+      if(level_str !== "debug" or agi.debug) do
+        Logger.bare_log(level, "ElixirAgi AGI: #{message}")
       end
     end
   end
@@ -56,10 +56,10 @@ defmodule ElixirAgi.Agi do
   @spec new(boolean) :: t
   def new(debug \\ false) do
     new(
-      fn() -> :ok end,
-      fn() -> :ok end,
-      fn() -> IO.gets "" end,
-      fn(data) -> IO.write data end,
+      fn -> :ok end,
+      fn -> :ok end,
+      fn -> IO.gets("") end,
+      fn data -> IO.write(data) end,
       debug
     )
   end
@@ -70,6 +70,7 @@ defmodule ElixirAgi.Agi do
   @spec new(init, close, reader, writer, boolean) :: t
   def new(init, close, reader, writer, debug) do
     :ok = init.()
+
     agi = %ElixirAgi.Agi{
       init: init,
       close: close,
@@ -78,42 +79,44 @@ defmodule ElixirAgi.Agi do
       variables: %{},
       debug: debug
     }
-    variables = read_variables agi
+
+    variables = read_variables(agi)
     %ElixirAgi.Agi{agi | variables: variables}
   end
 
   @doc """
   See: https://wiki.asterisk.org/wiki/display/AST/AGICommand_answer
   """
-  @spec answer(t) :: Result.t
+  @spec answer(t) :: Result.t()
   def answer(agi) do
-    exec agi, "ANSWER"
+    exec(agi, "ANSWER")
   end
 
   @doc """
   See: https://wiki.asterisk.org/wiki/display/AST/AGICommand_hangup
   """
-  @spec hangup(t, String.t) :: Result.t
+  @spec hangup(t, String.t()) :: Result.t()
   def hangup(agi, channel \\ "") do
-    exec agi, "HANGUP", [channel]
+    exec(agi, "HANGUP", [channel])
   end
 
   @doc """
   See: https://wiki.asterisk.org/wiki/display/AST/Asterisk+13+AGICommand_set+variable
   """
-  @spec set_variable(t, String.t, String.t) :: Result.t
+  @spec set_variable(t, String.t(), String.t()) :: Result.t()
   def set_variable(agi, name, value) do
-    run agi, "SET", ["VARIABLE", "#{name}", "#{value}"]
+    run(agi, "SET", ["VARIABLE", "#{name}", "#{value}"])
   end
 
   @doc """
   See: https://wiki.asterisk.org/wiki/display/AST/Asterisk+13+AGICommand_get+full+variable
   """
-  @spec get_full_variable(t, String.t) :: Result.t
+  @spec get_full_variable(t, String.t()) :: Result.t()
   def get_full_variable(agi, name) do
-    result = run agi, "GET", ["FULL", "VARIABLE", "${#{name}}"]
-     if result.result === "1" do
-      [_, var] = Regex.run ~r/\(([^\)]*)\)/, hd(result.extra)
+    result = run(agi, "GET", ["FULL", "VARIABLE", "${#{name}}"])
+
+    if result.result === "1" do
+      [_, var] = Regex.run(~r/\(([^\)]*)\)/, hd(result.extra))
       %Result{result | extra: var}
     else
       %Result{result | extra: nil}
@@ -123,51 +126,51 @@ defmodule ElixirAgi.Agi do
   @doc """
   See: https://wiki.asterisk.org/wiki/display/AST/Application_Dial
   """
-  @spec dial(t, String.t, non_neg_integer(), [String.t]) :: Result.t
+  @spec dial(t, String.t(), non_neg_integer(), [String.t()]) :: Result.t()
   def dial(agi, dial_string, timeout_seconds, options) do
-    exec agi, "DIAL", [
+    exec(agi, "DIAL", [
       dial_string,
       to_string(timeout_seconds),
       Enum.join(options, ",")
-    ]
+    ])
   end
 
   @doc """
   See: https://wiki.asterisk.org/wiki/display/AST/Application_Wait
   """
-  @spec wait(t, non_neg_integer()) :: Result.t
+  @spec wait(t, non_neg_integer()) :: Result.t()
   def wait(agi, seconds) do
-    exec agi, "WAIT", [seconds]
+    exec(agi, "WAIT", [seconds])
   end
 
   @doc """
   See: https://wiki.asterisk.org/wiki/display/AST/Application_AMD
   """
   @spec amd(
-    t,
-    non_neg_integer,
-    non_neg_integer,
-    non_neg_integer,
-    non_neg_integer,
-    non_neg_integer,
-    non_neg_integer,
-    non_neg_integer,
-    non_neg_integer,
-    non_neg_integer
-  ) :: Result.t
+          t,
+          non_neg_integer,
+          non_neg_integer,
+          non_neg_integer,
+          non_neg_integer,
+          non_neg_integer,
+          non_neg_integer,
+          non_neg_integer,
+          non_neg_integer,
+          non_neg_integer
+        ) :: Result.t()
   def amd(
-    agi,
-    initial_silence,
-    greeting,
-    after_greeting_silence,
-    total_time,
-    min_word_length,
-    between_words_silence,
-    max_words,
-    silence_threshold,
-    max_word_length
-  ) do
-    exec agi, "AMD", [
+        agi,
+        initial_silence,
+        greeting,
+        after_greeting_silence,
+        total_time,
+        min_word_length,
+        between_words_silence,
+        max_words,
+        silence_threshold,
+        max_word_length
+      ) do
+    exec(agi, "AMD", [
       initial_silence,
       greeting,
       after_greeting_silence,
@@ -177,173 +180,208 @@ defmodule ElixirAgi.Agi do
       max_words,
       silence_threshold,
       max_word_length
-    ]
+    ])
   end
 
   @doc """
   See: https://wiki.asterisk.org/wiki/display/AST/Asterisk+13+AGICommand_stream+file
   """
-  @spec stream_file(t, String.t, String.t) :: Result.t
+  @spec stream_file(t, String.t(), String.t()) :: Result.t()
   def stream_file(agi, file, escape_digits \\ "") do
-    run agi, "STREAM", ["FILE", file, escape_digits]
+    run(agi, "STREAM", ["FILE", file, escape_digits])
   end
 
   @doc """
   See: https://wiki.asterisk.org/wiki/display/AST/AGICommand_control+stream+file
   """
-  @spec control_stream_file(t, String.t, String.t, Integer.t, String.t, String.t, String.t) :: Result.t
-  def control_stream_file(agi, file, escape_digits \\ "", offset \\ 0, forward_digits \\ "", rewind_digits \\ "", pause_digits \\ "") do
-    run agi, "CONTROL STREAM", ["FILE", file, escape_digits, offset, forward_digits, rewind_digits, pause_digits]
+  @spec control_stream_file(
+          t,
+          String.t(),
+          String.t(),
+          Integer.t(),
+          String.t(),
+          String.t(),
+          String.t()
+        ) :: Result.t()
+  def control_stream_file(
+        agi,
+        file,
+        escape_digits \\ "",
+        offset \\ 0,
+        forward_digits \\ "",
+        rewind_digits \\ "",
+        pause_digits \\ ""
+      ) do
+    run(agi, "CONTROL", [
+      "STREAM",
+      "FILE",
+      file,
+      escape_digits,
+      offset,
+      forward_digits,
+      rewind_digits,
+      pause_digits
+    ])
   end
 
   @doc """
   See: https://wiki.asterisk.org/wiki/display/AST/AGICommand_exec
   """
-  @spec exec(t, String.t, [String.t]) :: Result.t
+  @spec exec(t, String.t(), [String.t()]) :: Result.t()
   def exec(agi, application, args \\ []) do
-    run agi, "EXEC", [application|args]
+    run(agi, "EXEC", [application | args])
   end
 
   @doc """
   See: https://wiki.asterisk.org/wiki/display/AST/AGICommand_get+data
   """
-  @spec get_data(t, String.t, Integer.t, Integer.t) :: Result.t
+  @spec get_data(t, String.t(), Integer.t(), Integer.t()) :: Result.t()
   def get_data(agi, file, timeout \\ 0, max_digits \\ 0) do
-    run agi, "GET DATA", [file, timeout, max_digits]
+    run(agi, "GET", ["DATA", file, timeout, max_digits])
   end
 
   @doc """
   See: https://wiki.asterisk.org/wiki/display/AST/AGICommand_get+option
   """
-  @spec get_option(t, String.t, String.t, Integer.t) :: Result.t
+  @spec get_option(t, String.t(), String.t(), Integer.t()) :: Result.t()
   def get_option(agi, file, escape_digits \\ "", timeout \\ 0) do
-    run agi, "GET OPTION", [file, escape_digits, timeout]
+    run(agi, "GET", ["OPTION", file, escape_digits, timeout])
   end
 
   @doc """
   See: https://wiki.asterisk.org/wiki/display/AST/AGICommand_record+file
   """
-  @spec record_file(t, String.t, String.t, String.t, Integer.t, Integer.t, boolean, Integer.t) :: Result.t
+  @spec record_file(
+          t,
+          String.t(),
+          String.t(),
+          String.t(),
+          Integer.t(),
+          Integer.t(),
+          boolean,
+          Integer.t()
+        ) :: Result.t()
   def record_file(
-   agi,
-   file,
-   format \\ "wav",
-   escape_digits \\ "",
-   timeout \\ 0,
-   offset \\ 0,
-   beep = false,
-   silence \\ 0
-   ) do
+        agi,
+        file,
+        format \\ "wav",
+        escape_digits \\ "",
+        timeout \\ 0,
+        offset \\ 0,
+        beep = false,
+        silence \\ 0
+      ) do
     args = [file, format, escape_digits, timeout, offset, beep]
+
     cond do
-      silence > 0 -> run agi, "RECORD FILE", args
-      true -> run agi, "RECORD FILE", [args | "s=" <> silence]
+      silence > 0 -> run(agi, "RECORD", ["FILE" | args])
+      true -> run(agi, "RECORD", ["FILE", args | "s=" <> silence])
     end
   end
 
   @doc """
   See: https://wiki.asterisk.org/wiki/display/AST/AGICommand_wait+for+digit
   """
-  @spec wait_for_digit(t, Integer.t) :: Result.t
+  @spec wait_for_digit(t, Integer.t()) :: Result.t()
   def wait_for_digit(agi, timeout \\ 0) do
-    run agi, "WAIT FOR DIGIT", [timeout]
+    run(agi, "WAIT", ["FOR", "DIGIT", timeout])
   end
 
   @doc """
   See: https://wiki.asterisk.org/wiki/display/AST/AGICommand_channel+status
   """
-  @spec channel_status(t, String.t) :: Result.t
+  @spec channel_status(t, String.t()) :: Result.t()
   def channel_status(agi, channel) do
-    run agi, "CHANNEL STATUS", [channel]
+    run(agi, "CHANNEL", ["STATUS", channel])
   end
 
   @doc """
   See: https://wiki.asterisk.org/wiki/display/AST/AGICommand_say+alpha
   """
-  @spec say_alpha(t, Integer.t, String.t) :: Result.t
+  @spec say_alpha(t, Integer.t(), String.t()) :: Result.t()
   def say_alpha(agi, number, escape_digits \\ "") do
-    run agi, "SAY ALPHA", [number, escape_digits]
+    run(agi, "SAY", ["ALPHA", number, escape_digits])
   end
 
   @doc """
   See: https://wiki.asterisk.org/wiki/display/AST/AGICommand_say+date
   """
-  @spec say_date(t, Integer.t, String.t) :: Result.t
+  @spec say_date(t, Integer.t(), String.t()) :: Result.t()
   def say_date(agi, elapsed_seconds, escape_digits \\ "") do
-    run agi, "SAY DATE", [elapsed_seconds, escape_digits]
+    run(agi, "SAY", ["DATE", elapsed_seconds, escape_digits])
   end
 
   @doc """
   See: https://wiki.asterisk.org/wiki/display/AST/AGICommand_say+datetime
   TODO: This function needs testing!
   """
-  @spec say_datetime(t, Integer.t, String.t) :: Result.t
+  @spec say_datetime(t, Integer.t(), String.t()) :: Result.t()
   def say_datetime(agi, elapsed_seconds, escape_digits \\ "", format \\ "", timezone \\ "") do
-    run agi, "SAY DATETIME", [elapsed_seconds, escape_digits, format, timezone]
+    run(agi, "SAY", ["DATETIME", elapsed_seconds, escape_digits, format, timezone])
   end
 
   @doc """
   See: https://wiki.asterisk.org/wiki/display/AST/AGICommand_say+digits
   """
-  @spec say_digits(t, Integer.t, String.t) :: Result.t
+  @spec say_digits(t, Integer.t(), String.t()) :: Result.t()
   def say_digits(agi, number, escape_digits \\ "") do
-    run agi, "SAY DIGITS", [number, escape_digits]
+    run(agi, "SAY", ["DIGITS", number, escape_digits])
   end
 
   @doc """
   See: https://wiki.asterisk.org/wiki/display/AST/AGICommand_say+number
   """
-  @spec say_number(t, Integer.t, String.t, String.t) :: Result.t
+  @spec say_number(t, Integer.t(), String.t(), String.t()) :: Result.t()
   def say_number(agi, number, escape_digits \\ "", gender \\ "c") do
-    run agi, "SAY NUMBER", [number, escape_digits, gender]
+    run(agi, "SAY", ["NUMBER", number, escape_digits, gender])
   end
 
   @doc """
   See: https://wiki.asterisk.org/wiki/display/AST/AGICommand_say+phonetic
   """
-  @spec say_phonetic(t, String.t, String.t) :: Result.t
+  @spec say_phonetic(t, String.t(), String.t()) :: Result.t()
   def say_phonetic(agi, string, escape_digits \\ "") do
-    run agi, "SAY PHONETIC", [string, escape_digits]
+    run(agi, "SAY", ["PHONETIC", string, escape_digits])
   end
 
   @doc """
   See: https://wiki.asterisk.org/wiki/display/AST/AGICommand_say+time
   """
-  @spec say_time(t, Integer.t, String.t) :: Result.t
+  @spec say_time(t, Integer.t(), String.t()) :: Result.t()
   def say_time(agi, time, escape_digits \\ "") do
-    run agi, "SAY TIME", [time, escape_digits]
+    run(agi, "SAY", ["TIME", time, escape_digits])
   end
 
   @doc """
   See: https://wiki.asterisk.org/wiki/display/AST/AGICommand_set+autohangup
   """
-  @spec set_autohangup(t, Integer.t) :: Result.t
+  @spec set_autohangup(t, Integer.t()) :: Result.t()
   def set_autohangup(agi, timespan) do
-    run agi, "SET AUTOHANGUP", [timespan]
+    run(agi, "SET", ["AUTOHANGUP", timespan])
   end
 
   @doc """
   See: https://wiki.asterisk.org/wiki/display/AST/AGICommand_set+callerid
   """
-  @spec set_callerid(t, String.t) :: Result.t
+  @spec set_callerid(t, String.t()) :: Result.t()
   def set_callerid(agi, callerid) do
-    run agi, "SET CALLERID", [callerid]
+    run(agi, "SET", ["CALLERID", callerid])
   end
 
   @doc """
   See: https://wiki.asterisk.org/wiki/display/AST/AGICommand_set+context
   """
-  @spec set_context(t, String.t) :: Result.t
+  @spec set_context(t, String.t()) :: Result.t()
   def set_context(agi, context) do
-    run agi, "SET CONTEXT", [context]
+    run(agi, "SET", ["CONTEXT", context])
   end
 
   @doc """
   See: https://wiki.asterisk.org/wiki/display/AST/AGICommand_set+extension
   """
-  @spec set_extension(t, String.t) :: Result.t
+  @spec set_extension(t, String.t()) :: Result.t()
   def set_extension(agi, extension) do
-    run agi, "SET EXTENSION", [extension]
+    run(agi, "SET", ["EXTENSION", extension])
   end
 
   @doc """
@@ -353,42 +391,48 @@ defmodule ElixirAgi.Agi do
     - cmd: Asterisk command name
     - args: List of asterisk command parameters in order of asterisk command docs
   """
-  @spec run(t, String.t, [String.t]) :: Result.t
+  @spec run(t, String.t(), [String.t()]) :: Result.t()
   def run(agi, cmd, args) do
     args = for a <- args, do: ["\"", to_string(a), "\" "]
-    cmd = ["\"", cmd, "\" "|args]
-    :ok = write agi, cmd
-    Result.new read(agi)
+    cmd = ["\"", cmd, "\" " | args]
+    :ok = write(agi, cmd)
+    Result.new(read(agi))
   end
 
-  @spec read_variables(t, Map.t) :: Map.t
+  @spec read_variables(t, Map.t()) :: Map.t()
   def read_variables(agi, vars \\ %{}) do
-    log :debug, "Reading next variable"
-    line = read agi
+    log(:debug, "Reading next variable")
+    line = read(agi)
+
     cond do
-      String.length(line) < 2 -> vars
+      String.length(line) < 2 ->
+        vars
+
       true ->
-        [k, v] = String.split line, ":", parts: 2
-        vars = Map.put vars, String.strip(k), String.strip(v)
-        read_variables agi, vars
+        [k, v] = String.split(line, ":", parts: 2)
+        vars = Map.put(vars, String.trim(k), String.trim(v))
+        read_variables(agi, vars)
     end
   end
 
   defp write(agi, data) do
-    log :debug, "Writing #{data}"
+    log(:debug, "Writing #{data}")
     :ok = agi.writer.([data, "\n"])
     :ok
   end
 
   defp read(agi) do
     line = agi.reader.()
-    {line, _} = String.split_at line, -1
-    log :debug, "Read #{line}"
+    {line, _} = String.split_at(line, -1)
+    log(:debug, "Read #{line}")
+
     case line do
       "HANGUP" <> _rest ->
         agi.close.()
         raise HangupError, "hangup"
-      _ -> line
+
+      _ ->
+        line
     end
   end
 end

--- a/lib/elixir_agi/fastagi.ex
+++ b/lib/elixir_agi/fastagi.ex
@@ -31,6 +31,8 @@ defmodule ElixirAgi.FastAgi do
   @type t :: ElixirAgi.FastAgi
   @typep state :: Map.t()
 
+  @timeout Application.get_env(:elixir_agi, :recv_timeout, 120_000)
+
   defmacro log(level, message) do
     quote do
       state = var!(state)
@@ -149,7 +151,7 @@ defmodule ElixirAgi.FastAgi do
           end
 
           reader = fn ->
-            {:ok, read_data} = :gen_tcp.recv(socket, 0)
+            {:ok, read_data} = :gen_tcp.recv(socket, 0, @timeout)
             read_data
           end
 

--- a/lib/elixir_agi/result.ex
+++ b/lib/elixir_agi/result.ex
@@ -15,24 +15,24 @@ defmodule ElixirAgi.Agi.Result do
   See the License for the specific language governing permissions and
   limitations under the License.
   """
-  defstruct \
-    code: nil,
-    success: nil,
-    result: nil,
-    extra: nil
+  defstruct code: nil,
+            success: nil,
+            result: nil,
+            extra: nil
 
   @type t :: ElixirAgi.Agi.Result
 
   @doc """
   Given a read line, parses it and returns a structure with the result.
   """
-  @spec new(String.t) :: t
+  @spec new(String.t()) :: t
   def new(line) do
-    [code, "result=" <> result|extra] = String.split line, " "
-    {code, ""} = Integer.parse code
+    [code, "result=" <> result | extra] = String.split(line, " ")
+    {code, ""} = Integer.parse(code)
+
     %ElixirAgi.Agi.Result{
       code: code,
-      success: (code === 200),
+      success: code === 200,
       result: result,
       extra: extra
     }

--- a/lib/elixir_agi/supervisor/fagi.ex
+++ b/lib/elixir_agi/supervisor/fagi.ex
@@ -21,7 +21,7 @@ defmodule ElixirAgi.Supervisor.FastAgi do
   @doc """
   Starts the supervisor.
   """
-  @spec start_link() :: Supervisor.on_start
+  @spec start_link() :: Supervisor.on_start()
   def start_link do
     Supervisor.start_link(__MODULE__, [], name: __MODULE__)
   end
@@ -30,18 +30,26 @@ defmodule ElixirAgi.Supervisor.FastAgi do
   Starts a supervised AGI application.
   """
   @spec new(
-    module, atom, boolean, atom, String.t, Integer.t, Integer.t
-  ) :: Supervisor.on_start_child
+          module,
+          atom,
+          boolean,
+          atom,
+          String.t(),
+          Integer.t(),
+          Integer.t()
+        ) :: Supervisor.on_start_child()
   def new(app_module, app_function, debug, name, host, port, backlog) do
-    Supervisor.start_child __MODULE__, [%ElixirAgi.FastAgi{
-      name: name,
-      host: host,
-      port: port,
-      backlog: backlog,
-      debug: debug,
-      app_module: app_module,
-      app_function: app_function
-    }]
+    Supervisor.start_child(__MODULE__, [
+      %ElixirAgi.FastAgi{
+        name: name,
+        host: host,
+        port: port,
+        backlog: backlog,
+        debug: debug,
+        app_module: app_module,
+        app_function: app_function
+      }
+    ])
   end
 
   @doc """
@@ -49,7 +57,8 @@ defmodule ElixirAgi.Supervisor.FastAgi do
   """
   @spec init([]) :: {:ok, tuple}
   def init([]) do
-    Logger.debug "ElixirAgi: Starting FastAGI supervisor"
+    Logger.debug("ElixirAgi: Starting FastAGI supervisor")
+
     children = [
       worker(ElixirAgi.FastAgi, [], restart: :transient)
     ]

--- a/lib/elixir_agi/supervisor/main.ex
+++ b/lib/elixir_agi/supervisor/main.ex
@@ -21,7 +21,7 @@ defmodule ElixirAgi.Supervisor.Main do
   @doc """
   Starts the supervisor
   """
-  @spec start_link() :: Supervisor.on_start
+  @spec start_link() :: Supervisor.on_start()
   def start_link do
     Supervisor.start_link(__MODULE__, [], name: __MODULE__)
   end
@@ -31,12 +31,13 @@ defmodule ElixirAgi.Supervisor.Main do
   """
   @spec init([]) :: {:ok, tuple}
   def init([]) do
-    Logger.debug "ElixirAgi: Starting main supervisor"
+    Logger.debug("ElixirAgi: Starting main supervisor")
+
     children = [
-      supervisor(ElixirAgi.Supervisor.FastAgi, [], [
+      supervisor(ElixirAgi.Supervisor.FastAgi, [],
         restart: :permanent,
         shutdown: :infinity
-      ])
+      )
     ]
 
     supervise(children, strategy: :one_for_one)

--- a/mix.exs
+++ b/mix.exs
@@ -10,8 +10,8 @@ defmodule ElixirAgi.Mixfile do
       source_url: "https://github.com/marcelog/elixir_agi",
       app: :elixir_agi,
       version: "0.0.20",
-      build_embedded: Mix.env == :prod,
-      start_permanent: Mix.env == :prod,
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
       deps: deps()
     ]
   end
@@ -25,9 +25,9 @@ defmodule ElixirAgi.Mixfile do
 
   defp description do
     """
-Elixir client for the Asterisk AGI protocol.
+    Elixir client for the Asterisk AGI protocol.
 
-Find the user guide in the github repo at: https://github.com/marcelog/elixir_agi.
+    Find the user guide in the github repo at: https://github.com/marcelog/elixir_agi.
     """
   end
 
@@ -45,7 +45,7 @@ Find the user guide in the github repo at: https://github.com/marcelog/elixir_ag
   defp deps do
     [
       {:earmark, "~> 1.0.3", only: :dev},
-      {:ex_doc, "~> 0.14.5", only: :dev},
+      {:ex_doc, "~> 0.14.5", only: :dev}
     ]
   end
 end


### PR DESCRIPTION
Hi @marcelog :)

AGI commands such as `["CONTROL STREAM FILE", ...]` wouldn't work and they needed to be like `["CONTROL", "STREAM", "FILE", ...]`

Another issue i have had was, In some versions of asterisk, the server wouldn't respond and stall but not close the connection, Therefore i have added a read timeout.

And because my editor automatically formats elixir files after saving (:angry:) i have added the formatter config and formatted all the code in this repo. (I'm sorry)

If you don't like the way that the code is formatted, I can revert my changes and do them again without any formatting.

Thank you. :heart: 